### PR TITLE
fix: validate altcha only if value is a string

### DIFF
--- a/Classes/Validation/Captcha/CaptchaValidator.php
+++ b/Classes/Validation/Captcha/CaptchaValidator.php
@@ -35,8 +35,7 @@ class CaptchaValidator extends AbstractValidator
         }
         if (!is_string($value)) {
             $this->addError('Value must be of type string.', 1751545289);
-        }
-        if ($this->altchaService->validate($value) === false) {
+        } else if ($this->altchaService->validate($value) === false) {
             $this->addError('Value was not validated correctly.', 1742223424);
         }
     }


### PR DESCRIPTION
## Bugfix

- Validation of altcha Service is trigered only when the value definitly is a string. 
    - In the old way, there was an exception thrown when the input was empty: Argument was `null` when `string` was expected. This cluttered exception monitoring like Sentry and alike.